### PR TITLE
Location scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tmp
 e2e/node_modules
 e2e/cypress/screenshots
 e2e/cypress/videos
+e2e/cypress/fixtures
 
 # VSCode keeps generating these, need to investigate.
 *.tmp

--- a/apps/curbside_concerts_web/assets/css/_badge.scss
+++ b/apps/curbside_concerts_web/assets/css/_badge.scss
@@ -1,0 +1,25 @@
+.badge {
+  display: inline-block;
+  min-width: 1.5em;
+  min-height: 1.5em;
+  padding: .3em;
+  border-radius: 50%;
+  font-size: 16px;
+  text-align: center;
+  background: #1779ba;
+  color: #fefefe;
+
+  &.best {
+    background: green;
+  }
+  &.better {
+    background: yellowgreen;
+  }
+  &.good {
+    background: yellowgreen;
+  }
+  &.bad {
+    background: #880000;
+  }
+
+}

--- a/apps/curbside_concerts_web/assets/css/app.scss
+++ b/apps/curbside_concerts_web/assets/css/app.scss
@@ -4,6 +4,7 @@
 @import "./landing";
 @import "./request-form";
 @import "./tips";
+@import "./badge";
 
 .field {
 	display: block;
@@ -133,6 +134,13 @@ div#address_container {
 
 				.card {
 					margin: 8px 0;
+					position: relative;
+
+					.badge {
+						position: absolute;
+						top: 4px;
+						right: 4px;
+					}
 				}
 			}
 		}

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/live/session_booker_live.ex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/live/session_booker_live.ex
@@ -11,6 +11,7 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
   alias CurbsideConcerts.Requests.Request
   alias CurbsideConcertsWeb.RequestView
   alias CurbsideConcertsWeb.Helpers.RequestAddress
+  alias CurbsideConcertsWeb.ZipCodeSessionScorer
 
   def mount(%{"session_id" => session_id} = _params, _session, socket) do
     unbooked_requests = Requests.all_unbooked_requests()
@@ -194,13 +195,15 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
         <%= if @saved do %>
           <br><br>SAVED!
         <% end %>
+        <br>
+        Badge scores <span class="badge good">70</span> are based on the requests' ZIP codes and how close they are to the locations on the route booked so far, including the truck pickup location.
       </div>
       <div class="columns">
         <div class="column">
           <h2>Unbooked Requests (<%= length(@unbooked_requests) %>)</h2>
 
           <%= for request <- @unbooked_requests do %>
-            <%= render_request_card(assigns, request) %>
+            <%= render_request_card(assigns, request, @session_requests) %>
           <% end %>
           <%= if @unbooked_requests == [] do %>
             <div class="card">
@@ -216,7 +219,7 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
             <%= RequestView.map_route_link(@session_requests) %>
           <% end %>
           <%= for request <- @session_requests do %>
-            <%= render_request_card(assigns, request) %>
+            <%= render_request_card(assigns, request, @session_requests) %>
           <% end %>
           <%= if @session_requests == [] do %>
             <div class="card">
@@ -234,7 +237,8 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
          %Request{
            id: request_id,
            special_message: special_message
-         } = request
+         } = request,
+         comparing_requests
        ) do
     ~L"""
     <div phx-hook="RequestBookerCard"
@@ -242,6 +246,7 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
          class="draggable-card"
          draggable="true">
       <div class="card">
+        <%= zip_score(assigns, request, comparing_requests) %>
         <b>email:</b> <%= request.requester_email %><br>
         <b>genres:</b> <%= Enum.map(request.genres, fn g -> g.name end) |> Enum.join(", ") %><br>
         <b>Address:</b> <%= RequestAddress.full_address(request) %><br>
@@ -255,5 +260,29 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
       </div>
     </div>
     """
+  end
+
+  defp zip_score(assigns, request, comparing_requests) do
+    other_zips = ["43215" | Enum.map(comparing_requests, &zip/1)]
+    score = ZipCodeSessionScorer.score(zip(request), other_zips)
+
+    class =
+      case score do
+        score when score >= 80 -> "best"
+        score when score >= 60 -> "better"
+        score when score >= 40 -> "good"
+        _ -> "bad"
+      end
+
+    ~L"""
+    <div class="badge <%= class %>"><%= score %></div>
+    """
+  end
+
+  defp zip(%Request{nominee_address: nominee_address}) do
+    case Regex.run(~r/43\d{3}/, nominee_address) do
+      [zip] -> zip
+      _ -> "439#{Enum.random(10..99)}"
+    end
   end
 end

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/live/session_booker_live.ex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/live/session_booker_live.ex
@@ -236,7 +236,8 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
          assigns,
          %Request{
            id: request_id,
-           special_message: special_message
+           special_message: special_message,
+           nominee_address_notes: address_notes
          } = request,
          comparing_requests
        ) do
@@ -249,7 +250,7 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
         <%= zip_score(assigns, request, comparing_requests) %>
         <b>email:</b> <%= request.requester_email %><br>
         <b>genres:</b> <%= Enum.map(request.genres, fn g -> g.name end) |> Enum.join(", ") %><br>
-        <b>Address:</b> <%= RequestAddress.full_address(request) %><br>
+        <b>Address:</b> <%= RequestAddress.full_address(request) %> <%= address_notes %><br>
         <b>Special Message:</b> <%= special_message %><br>
         <b>state:</b> <%= request.state %><br>
         <b>contact_preference:</b> <%= request.contact_preference %><br>
@@ -278,6 +279,8 @@ defmodule CurbsideConcertsWeb.SessionBookerLive do
     <div class="badge <%= class %>"><%= score %></div>
     """
   end
+
+  defp zip(%Request{nominee_zip_code: zip}) when is_binary(zip), do: zip
 
   defp zip(%Request{nominee_address: nominee_address}) do
     case Regex.run(~r/43\d{3}/, nominee_address) do

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/request_card.html.eex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/request/request_card.html.eex
@@ -25,7 +25,7 @@
   </div>
 
   <%= if nominee_address_notes do %>
-    <div> 
+    <div>
       <b>Address Instructions:</b><br>
       <%= raw nominee_address_notes %>
     </div>

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/session/driver_session_route.html.eex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/session/driver_session_route.html.eex
@@ -4,6 +4,7 @@
 <%= for %Request{
   nominee_name: nominee_name,
   nominee_phone: nominee_phone,
+  nominee_address_notes: nominee_address_notes,
   requester_name: requester_name,
   requester_phone: requester_phone,
   requester_email: requester_email,
@@ -19,6 +20,12 @@
       <b>Map to <%= nominee_name %>'s house:</b>
       <a href="http://maps.google.com/?q=<%= URI.encode(RequestAddress.full_address(request)) %>"><%= RequestAddress.full_address(request) %></a>
     </div>
+
+    <%= if nominee_address_notes do %>
+      <div>
+        <b>Address Instructions:</b> <%= raw nominee_address_notes %>
+      </div>
+    <% end %>
 
     <br>
 

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/session/musician_session_route.html.eex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/templates/session/musician_session_route.html.eex
@@ -2,15 +2,15 @@
 <%= RequestView.map_route_link(@session.requests) %>
 
 <%= for %Request{
-  nominee_address: nominee_address,
+  nominee_address_notes: nominee_address_notes,
   nominee_name: nominee_name,
   requester_name: requester_name,
   special_message: special_message,
   genres: genres
-} <- @session.requests do %>
+} = request <- @session.requests do %>
   <div class="card">
     <div>
-      <b>Arriving at:</b> <%= nominee_address %>
+      <b>Arriving at:</b> <%= RequestAddress.full_address(request) %> <%= nominee_address_notes %>
     </div>
 
     <br>

--- a/apps/curbside_concerts_web/lib/curbside_concerts_web/zip_code_session_scorer.ex
+++ b/apps/curbside_concerts_web/lib/curbside_concerts_web/zip_code_session_scorer.ex
@@ -1,0 +1,193 @@
+defmodule CurbsideConcertsWeb.ZipCodeSessionScorer do
+  @moduledoc """
+  Columbus ZIP code scorer. Based off of the proximity of ZIP codes,
+  a score can be awarded to a ZIP in relation to other ZIPs.
+
+  This is to be used in the session booker to give a better idea
+  which requests are in the route area.
+  """
+
+  alias CurbsideConcertsWeb.ZipCodeDistanceStore
+
+  @connected_zips %{
+    004 => [062, 054, 230, 213, 068],
+    013 => [074, 031],
+    016 => [064, 017, 065, 235, 026],
+    017 => [016, 235, 064],
+    021 => [074, 082, 035],
+    026 => [016, 119, 162],
+    031 => [013, 074, 021, 082],
+    035 => [021, 065, 240, 082],
+    040 => [061, 064],
+    054 => [031, 081, 230, 004, 062],
+    061 => [040],
+    062 => [054, 004, 068],
+    064 => [040, 016, 026, 054],
+    065 => [016, 107, 235, 035],
+    068 => [062, 004, 213, 232, 147],
+    074 => [013, 031, 021],
+    081 => [082, 231, 230, 054],
+    082 => [021, 031, 081, 240, 035],
+    085 => [235, 214, 229],
+    102 => [130, 110],
+    103 => [102, 110, 125, 137, 146, 116],
+    110 => [130, 147, 068, 232, 125, 136, 112],
+    112 => [110],
+    116 => [103, 146],
+    119 => [162, 026, 228, 123],
+    123 => [146, 140, 119, 228, 204, 223],
+    125 => [110, 217, 232, 207, 137],
+    126 => [146],
+    130 => [110, 102],
+    136 => [110],
+    137 => [217, 125, 207, 103],
+    140 => [123, 146],
+    143 => [146],
+    146 => [126, 140, 123, 116, 143, 103, 137],
+    147 => [068, 110],
+    162 => [119, 026],
+    201 => [202, 211, 219, 203, 215, 212],
+    202 => [214, 224, 211, 201, 210, 221],
+    203 => [219, 205, 206, 215],
+    204 => [228, 223, 222, 212, 221],
+    205 => [215, 203, 206, 209],
+    206 => [215, 205, 209, 207],
+    207 => [137, 125, 223, 232],
+    209 => [213, 227, 232, 207, 206, 205, 203, 219],
+    210 => [202, 201, 212, 221],
+    211 => [224, 219, 201, 202],
+    212 => [221, 210, 201, 215, 204],
+    213 => [068, 232, 227, 209, 004, 230, 218],
+    214 => [085, 229, 224, 202, 220, 235],
+    215 => [222, 212, 201, 203, 205, 206],
+    217 => [137, 125],
+    219 => [211, 224, 230, 213, 209, 203],
+    220 => [235, 214, 221],
+    221 => [026, 220, 202, 210, 212],
+    222 => [215, 223, 204],
+    223 => [222, 204, 207, 123],
+    224 => [229, 231, 219, 211, 202, 214],
+    227 => [213, 209, 232],
+    228 => [026, 119, 123, 204],
+    229 => [085, 214, 224, 231, 081],
+    230 => [054, 004, 213, 219, 231, 081],
+    231 => [229, 081, 230, 224],
+    232 => [068, 110, 125, 207, 227, 213, 209],
+    235 => [016, 017, 220, 214, 085],
+    240 => [035, 082, 081]
+  }
+
+  def zips do
+    Map.keys(@connected_zips)
+  end
+
+  def score(zip, list) when is_binary(zip) and is_list(list) do
+    score(zip_to_code(zip), Enum.map(list, &zip_to_code/1))
+  end
+
+  def score(_zip, []), do: 100
+
+  @doc """
+  If you are already in the same ZIP, automatic 100.
+
+  Otherwise a score between 0 and 100 is given based on the proximity
+  of your zip to the other_zips.
+  """
+  def score(zip, other_zips) do
+    if Enum.member?(other_zips, zip) do
+      100
+    else
+      amount =
+        other_zips
+        |> Enum.map(fn other_zip ->
+          score = 11 - (distance(zip, other_zip) || 100)
+          Enum.min([Enum.max([0, score]), 10])
+        end)
+        |> Enum.sum()
+
+      div(amount * 10, length(other_zips))
+    end
+  end
+
+  def zip_to_code("43" <> <<rest::binary>>) do
+    String.to_integer(rest)
+  end
+
+  def zip_to_code(_), do: 999
+
+  def distance(same_zip, same_zip), do: 0
+
+  def distance(zip_a, zip_b) do
+    ZipCodeDistanceStore.maybe_start(__MODULE__)
+
+    ZipCodeDistanceStore.do_distance(__MODULE__, zip_a, zip_b, &build_steps/1)
+  end
+
+  def build_steps(zip) do
+    do_build_steps(1, [[zip]], zip)
+  end
+
+  def do_build_steps(step, history, zip) do
+    next_level_zips =
+      @connected_zips
+      |> Map.take(List.first(history))
+      |> Enum.flat_map(fn {_, b} -> b end)
+      |> Enum.uniq()
+
+    next_level_zips = next_level_zips -- List.flatten(history)
+
+    if next_level_zips != [] do
+      Enum.each(next_level_zips, fn next_level_zip ->
+        ZipCodeDistanceStore.put(__MODULE__, zip, next_level_zip, step)
+      end)
+
+      do_build_steps(step + 1, [next_level_zips | history], zip)
+    end
+  end
+end
+
+defmodule CurbsideConcertsWeb.ZipCodeDistanceStore do
+  use GenServer
+
+  def do_distance(name, zip_a, zip_b, build_steps_fun) do
+    case get(name, zip_a, zip_b) do
+      nil ->
+        build_steps_fun.(zip_a)
+        get(name, zip_a, zip_b)
+
+      result ->
+        result
+    end
+  end
+
+  defp get(name, zip_a, zip_b) do
+    GenServer.call(name, {:get, {zip_a, zip_b}})
+  end
+
+  def put(name, zip_a, zip_b, distance) do
+    GenServer.call(name, {:put, {zip_b, zip_a}, distance})
+    GenServer.call(name, {:put, {zip_a, zip_b}, distance})
+  end
+
+  def maybe_start(name) do
+    case GenServer.start_link(__MODULE__, [], name: name) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        :ok
+    end
+  end
+
+  def init(_) do
+    {:ok, %{}}
+  end
+
+  def handle_call({:get, {zip_a, zip_b}}, _from, state) do
+    {:reply, Map.get(state, {zip_a, zip_b}), state}
+  end
+
+  def handle_call({:put, {zip_a, zip_b}, value}, _from, state) do
+    {:reply, :ok, Map.put(state, {zip_a, zip_b}, value)}
+  end
+end


### PR DESCRIPTION
Location scores to help determine the best requests in the session booker.

 It uses only the ZIP codes to determine proximity.

The score is calculated based off of the ZIP of the truck pickup and all other requests in the session already. A score close to 100 means the request is likely close to one of the other requests booked or near the truck pickup location. A score of 0 means it’s not near anything you’ve set up so far.

NOTE: All of the scores will adjust every time you move a request.

![image](https://user-images.githubusercontent.com/57177/79464743-75841a80-7fc8-11ea-9785-880449457080.png)
